### PR TITLE
Store Airports in the database

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,5 +48,5 @@ app.listen(PORT, async () => {
 
     await connect();
 
-    AirLabs.dataCollector();
+    //AirLabs.dataCollector();
 });

--- a/models/Airport.js
+++ b/models/Airport.js
@@ -1,17 +1,24 @@
+//According to AirLabs the API won't provide to much info about the aiports while we use the free plan
+//Found this website that gives you a spreadsheet what we need https://ourairports.com/data/
+//Then parsed to JSON using https://csvjson.com
+//Importing this data into our database.
 const mongoose = require("mongoose");
 const axios = require("axios");
 
 const airportSchema = mongoose.Schema({
-    name: { type: String },
-    iata_code: { type: String },
+    id: { type: Number },
     icao_code: { type: String },
-    lat: { type: String },
-    lng: { type: String },
-    alt: { type: String },
-    city: { type: String },
-    city_code: { type: String },
-    un_locode: { type: String },
+    iata_code: { type: String },
+    name: { type: String },
+    lat: { type: Number },
+    lng: { type: Number },
+    alt: { type: Number },
+    continent: { type: String },
     country_code: { type: String },
+    iso_region: { type: String },
+    city: { type: String },
+    website: { type: String },
+    wikipedia_link: { type: String },
 });
 
 module.exports = mongoose.model("Airport", airportSchema);

--- a/routes/airport.js
+++ b/routes/airport.js
@@ -3,15 +3,38 @@ const Router = express.Router();
 const mongoose = require("mongoose");
 const Airport = require("../models/Airport");
 
-//Returns a picture given an Aircraft's registration code
-Router.get("/api/airport/", async (req, res) => {
-    const iata_code = req.params.iata_code;
-    const icao_code = req.params.icao_code;
+const AirportDefault = require("../default_data/airports");
 
-    var airports = await Airport.find();
-    return res.send(airports);
+//Returns an airport given the iata_code and/or the icao_code
+Router.get("/api/airport/", async (req, res) => {
+    try {
+        const iata_code = req.query.iata_code;
+        const icao_code = req.query.icao_code;
+
+        let query = {};
+        if (icao_code) {
+            query.icao_code = icao_code;
+        }
+        if (iata_code) {
+            query.iata_code = iata_code;
+        }
+
+        var airports = await Airport.find(query);
+        if (airports?.length > 0) {
+            return res.send(airports[0]);
+        } else {
+            res.status(500).send({
+                error: `No airport found with IATA: ${iata_code} and ICAO: ${icao_code}`,
+            });
+        }
+    } catch (error) {
+        res.status(500).send({ error: error });
+    }
 });
 
-Router.post("/api/airport/populatedb", async (req, res) => {});
+Router.post("/api/airport/populatedb", async (req, res) => {
+    await Airport.insertMany(AirportDefault);
+    return res.send("ok");
+});
 
 module.exports = { Router };

--- a/utils/airlabs.js
+++ b/utils/airlabs.js
@@ -153,7 +153,8 @@ class AirLabs {
             flightsArray
                 .filter((elem) => elem?.updated < latestUpdateTime - 600)
                 .forEach((f) => {
-                    this.#airlabsSnapshot[f.hex] = undefined;
+                    //this.#airlabsSnapshot[f.hex] = undefined;
+                    delete this.#airlabsSnapshot[f.hex];
                     deletedFlightCount++;
                 });
             this.printLog("Finished Storing data.", true);


### PR DESCRIPTION
Added an airports array to default_data/airport.js
This array can be used to populate the database in case this one is empty, in order to do that send a POST to /api/airline/populatedb.

Also added the Airport schema, the Airport route.
To get an Airport info send a GET request to /api/airline/ with two optional parameters iata_code and icao_code, this search matches in the databse and returns the first one.